### PR TITLE
Pickups

### DIFF
--- a/BasicMechanicsDemo/Assets/Materials/Temp/Temp_SpellPickup.mat
+++ b/BasicMechanicsDemo/Assets/Materials/Temp/Temp_SpellPickup.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Temp_SpellPickup
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 0.18961917, g: 0, b: 1, a: 0.228}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/BasicMechanicsDemo/Assets/Materials/Temp/Temp_SpellPickup.mat.meta
+++ b/BasicMechanicsDemo/Assets/Materials/Temp/Temp_SpellPickup.mat.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 94a8a2f0b08ce4381850aef4fd30bb10
+timeCreated: 1508575006
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Prefabs/Item_Default.prefab
+++ b/BasicMechanicsDemo/Assets/Prefabs/Item_Default.prefab
@@ -1,0 +1,208 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1037877941852264}
+  m_IsPrefabParent: 1
+--- !u!1 &1037877941852264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4433612437280580}
+  - component: {fileID: 65657167291037762}
+  - component: {fileID: 114592296832359736}
+  m_Layer: 0
+  m_Name: Item_Default
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1604421790146032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4238655695930528}
+  - component: {fileID: 212649925435268962}
+  m_Layer: 0
+  m_Name: ItemSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1788500784810062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4321561252207594}
+  - component: {fileID: 33775986658922666}
+  - component: {fileID: 23245839886808590}
+  m_Layer: 0
+  m_Name: Item_VisualizationAid
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4238655695930528
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1604421790146032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4433612437280580}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4321561252207594
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1788500784810062}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4433612437280580}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4433612437280580
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1037877941852264}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -10.75, y: 0.54999995, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4321561252207594}
+  - {fileID: 4238655695930528}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23245839886808590
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1788500784810062}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 5b1488474347740409153e4ec5a6bfc8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33775986658922666
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1788500784810062}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &65657167291037762
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1037877941852264}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &114592296832359736
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1037877941852264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe0f737b8f241448f863f6e4749abee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &212649925435268962
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1604421790146032}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0

--- a/BasicMechanicsDemo/Assets/Prefabs/Item_Default.prefab.meta
+++ b/BasicMechanicsDemo/Assets/Prefabs/Item_Default.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 750d10d3c9a5043cba4860f04494c345
+timeCreated: 1508573251
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Prefabs/Spell.meta
+++ b/BasicMechanicsDemo/Assets/Prefabs/Spell.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 17feb5aa3087b46eebb6a447a1fd1b4a
+folderAsset: yes
+timeCreated: 1508565863
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Prefabs/Spell_Default.prefab
+++ b/BasicMechanicsDemo/Assets/Prefabs/Spell_Default.prefab
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1560220320337108}
+  m_IsPrefabParent: 1
+--- !u!1 &1176712110057788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4590790673462154}
+  - component: {fileID: 212258759554013966}
+  m_Layer: 0
+  m_Name: SpellSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1560220320337108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4428925342954768}
+  - component: {fileID: 65758395286044110}
+  - component: {fileID: 114373048042979178}
+  m_Layer: 0
+  m_Name: Spell_Default
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1716665077550008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4367116266428314}
+  - component: {fileID: 33279127392884800}
+  - component: {fileID: 65572358553984718}
+  - component: {fileID: 23042374926041172}
+  m_Layer: 0
+  m_Name: Spell_VisualizationAid
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4367116266428314
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1716665077550008}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4428925342954768}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4428925342954768
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1560220320337108}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.12, y: 0.55, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4590790673462154}
+  - {fileID: 4367116266428314}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4590790673462154
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1176712110057788}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4428925342954768}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23042374926041172
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1716665077550008}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 94a8a2f0b08ce4381850aef4fd30bb10, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33279127392884800
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1716665077550008}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &65572358553984718
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1716665077550008}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65758395286044110
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1560220320337108}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &114373048042979178
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1560220320337108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30cf0c89709fe4bbf8f55dd076be4de6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &212258759554013966
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1176712110057788}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0

--- a/BasicMechanicsDemo/Assets/Prefabs/Spell_Default.prefab.meta
+++ b/BasicMechanicsDemo/Assets/Prefabs/Spell_Default.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 55f288681366942dc955c6fa8d67c7e3
+timeCreated: 1508573253
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
+++ b/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
@@ -1435,6 +1435,7 @@ GameObject:
   m_Component:
   - component: {fileID: 872955988}
   - component: {fileID: 872955987}
+  - component: {fileID: 872955989}
   m_Layer: 5
   m_Name: SceneManagers
   m_TagString: Untagged
@@ -1473,6 +1474,22 @@ RectTransform:
   m_AnchoredPosition: {x: -7809.2983, y: 821.7011}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &872955989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872955986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b69754a7e4cc4d5480b732a6704360b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TempItemPrefab: {fileID: 1037877941852264, guid: 750d10d3c9a5043cba4860f04494c345,
+    type: 2}
+  m_TempSpellPrefab: {fileID: 1560220320337108, guid: 55f288681366942dc955c6fa8d67c7e3,
+    type: 2}
+  m_Player: {fileID: 1546207769}
 --- !u!1 &959023633
 GameObject:
   m_ObjectHideFlags: 0
@@ -2338,7 +2355,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6a88e2198a674f749006c8526d32183, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MaximalVelocity: 10
+  m_MaximalVelocity: 8
 --- !u!95 &1546207773
 Animator:
   serializedVersion: 3

--- a/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/Inventory/PlayerInventory.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/Inventory/PlayerInventory.cs
@@ -1,72 +1,76 @@
-﻿//#define TESTING
+﻿#define TESTING_INVENTORY_CONTENTS_OUTPUT
+#define TESTING_INVENTORY_SPELLPICKUP
 
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+//Ensure the player's got his capsule collider
+[RequireComponent(typeof(CapsuleCollider))]
 
 public class PlayerInventory : MonoBehaviour {
 	/**A list of all spells in the inventory.*/
 	public List<Spell> m_SpellList { private set; get; }
 	/**A List of all items in the inventory.*/
-	public List<Item> m_ItemList {private set; get;}
-
+	public Dictionary<Item, int> m_ItemDictionary {private set; get;}
 
 	void Start()
 	{
 		//Initialize Spell List
 		this.m_SpellList = new List<Spell> ();
-		for (int index = 0; index < System.Enum.GetValues (typeof(SpellName)).Length; index++) {
-			switch (index) {
-			//Case Fireball
-			case (int)SpellName.Fireball:
-				{
-					Spell fireball = new Spell ();
-					fireball.m_SpellEffect = SpellEffect.Fire_Damage;
-					fireball.m_SpellName = SpellName.Fireball;
-					this.m_SpellList.Add (fireball);
-					break;
-				}//end case Fireball
-
-				//and so on...
-			
-			default:
-				{
-					break;
-				}//end case default
-			}//end switch
-		}//end for
-
-		//Initialize Item Dictionary
-		this.m_ItemList = new List<Item>();
-		for (int index = 0; index < System.Enum.GetValues (typeof(ItemName)).Length; index++) {
-			switch (index) {
-			//Case Health Potion
-			case (int)ItemName.Health_Potion:
-				{
-					Item health_potion = new Item ();
-					health_potion.m_ItemName = ItemName.Health_Potion;
-					health_potion.m_ItemEffect = ItemEffect.Gain_Health;
-					//Start off with none
-					health_potion.m_Quantity = 0;
-					this.m_ItemList.Add(health_potion);
-					break;
-				}//end case Health Potion
-
-				//and so on...
-
-			default:
-				{
-					break;
-				}//end case default
-			}//end switch
-
-		}//end for
+		this.m_ItemDictionary = new Dictionary<Item, int> ();
+//		for (int index = 0; index < System.Enum.GetValues (typeof(SpellName)).Length; index++) {
+//			switch (index) {
+//			//Case Fireball
+//			case (int)SpellName.Fireball:
+//				{
+//					Spell fireball = new Spell ();
+//					fireball.m_SpellEffect = SpellEffect.Fire_Damage;
+//					fireball.m_SpellName = SpellName.Fireball;
+//					fireball.m_HasBeenDiscovered = false;
+//					this.m_SpellList.Add (fireball);
+//					break;
+//				}//end case Fireball
+//
+//				//and so on...
+//			
+//			default:
+//				{
+//					break;
+//				}//end case default
+//			}//end switch
+//		}//end for
+//
+//		//Initialize Item Dictionary
+//		this.m_ItemDictionary = new Dictionary<Item, int>();
+//		for (int index = 0; index < System.Enum.GetValues (typeof(ItemName)).Length; index++) {
+//			switch (index) {
+//			//Case Health Potion
+//			case (int)ItemName.Health_Potion:
+//				{
+//					Item health_potion = new Item ();
+//					health_potion.m_ItemName = ItemName.Health_Potion;
+//					health_potion.m_ItemEffect = ItemEffect.Gain_Health;
+//					//Start off with none
+////					health_potion.m_Quantity = 0;
+//					this.m_ItemDictionary.Add(health_potion, 0);
+//					break;
+//				}//end case Health Potion
+//
+//				//and so on...
+//
+//			default:
+//				{
+//					break;
+//				}//end case default
+//			}//end switch
+//
+//		}//end for
 	}//end f'n void Start()
 
 	void Update()
 	{
-		#if TESTING
+		#if TESTING_INVENTORY_CONTENTS_OUTPUT
 		if (Input.GetKeyDown (KeyCode.Return)) {
 			this.OutputInventoryContents ();
 		}
@@ -79,11 +83,11 @@ public class PlayerInventory : MonoBehaviour {
 		string message = "Inventory Contents:\n";
 		message += "Spells:\n";
 		foreach (Spell spell in this.m_SpellList) {
-			message += "Spell name: " + spell.m_SpellName.ToString () + "\tSpell Effect: " + spell.m_SpellEffect.ToString() + "\n";
+			message += "Spell name: " + spell.m_SpellName.ToString () + "\tSpell Effect: " + spell.m_SpellEffect.ToString() + "\tisDiscovered? " + spell.m_HasBeenDiscovered + "\n";
 		}//end foreach
 		message += "Items:\n";
-		foreach (Item item in this.m_ItemList) {
-			message += "Item name: " + item.m_ItemName.ToString () + "\tItem Effect: " + item.m_ItemEffect.ToString () + "\tItem Quantity:\t" + item.m_Quantity + "\n";
+		foreach (KeyValuePair<Item, int> entry in this.m_ItemDictionary) {
+			message += "Item name: " + entry.Key.m_ItemName.ToString () + "\tItem Effect: " + entry.Key.m_ItemEffect.ToString () + "\tItem Quantity:\t" + entry.Value + "\n";
 		}//end foreach
 		Debug.Log(message);
 	}//end f'n void OutputInventoryContents()
@@ -119,4 +123,59 @@ public class PlayerInventory : MonoBehaviour {
 //		}//end foreach
 //		return dictionary_to_return;
 //	}
-}
+
+	void OnTriggerEnter(Collider other)
+	{
+		//if the other's gameobject has an item component...
+		if (other.gameObject.GetComponent<Item> () != null) {
+			//For some reason, this function is getting called twice immediately. Uncomment the following line to see.
+			Debug.Log("PlayerInventory::OnTriggerEnter::Item running");
+
+			Item pickedup_item = other.gameObject.GetComponent<Item> ();
+
+			//if the dictionary contains key pickedup_item...
+			if (this.m_ItemDictionary.ContainsKey (pickedup_item)) {
+				//...then increment to the quantity of the item
+				this.m_ItemDictionary [pickedup_item]++;
+			}//end if
+			//else if the dictionary doesn't contain key pickedup_item...
+			else {
+				//...then add the Item key with quantity 1.
+				this.m_ItemDictionary.Add (pickedup_item, 1);
+			}//end else
+			//Destroy picked-up item
+			GameObject.Destroy(other.gameObject);
+		}//end if
+
+		/*
+		* Note: We assume the only time the player will ever encounter a spell is if the player hasn't yet discovered them.
+		* That being said, I won't take chances with the code.
+		*/
+
+		//if the other's gameobject has a spell component...
+		if (other.gameObject.GetComponent<Spell> () != null) {
+			Spell spell_picked_up = other.gameObject.GetComponent<Spell> ();
+			//set to true if any spells have the same name
+			bool spell_of_same_name = false;
+			foreach (Spell spell_in_list in this.m_SpellList)
+			{
+				//if the spell we're picking up has the same name as another spell in the list...
+				if (spell_in_list.m_SpellName == spell_picked_up.m_SpellName) {
+					//update spell_of_same_name
+					spell_of_same_name = true;
+					//...update m_HasBeenDiscovered
+					if (spell_in_list.m_HasBeenDiscovered != true) {
+						spell_in_list.m_HasBeenDiscovered = true;
+					}//end if
+				}//end if
+			}//end foreach
+			//if none of the spells in the spell list had the same name...
+			if (!spell_of_same_name) {
+				//...then add the spell to the list
+				spell_picked_up.m_HasBeenDiscovered = true;
+				this.m_SpellList.Add (spell_picked_up);
+			}//end if
+			GameObject.Destroy(other.gameObject);
+		}//end if
+	}//end f'n void OnTriggerEnter(Collider)
+}//end class PlayerInventory

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/TagList.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/TagList.cs
@@ -1,0 +1,14 @@
+﻿/**
+* A class to keep track of the tags.
+*/
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TagList : MonoBehaviour {
+	/**A string to keep the value of our tag for item objects.*/
+	public readonly string ITEM = "Item";
+	/**A string to keep the value of our tag for spell objects.*/
+	public readonly string SPELL = "Spell";
+}

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/TagList.cs.meta
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/TagList.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9be66fddb71cd4114a86b24e0fd3ac27
+timeCreated: 1508567559
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Scripts/Item.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Item.cs
@@ -1,12 +1,21 @@
-﻿using System.Collections;
+﻿/**
+* A script to manage the Items both in and out of the player inventory
+*/
+
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(BoxCollider))]
 public class Item : MonoBehaviour {
 	/**An enum variable for the item name. See ItemName.cs for all item names.*/
 	public ItemName m_ItemName { set; get; }
 	/**An enum variable for the item effect. See ItemEffect.cs for all item effects.*/
 	public ItemEffect m_ItemEffect { set; get;}
-	/**An int to tell us the quantity of the item in the player's inventory.*/
-	public int m_Quantity;
+
+	void Awake()
+	{
+		//ensure the box collider's isTrigger is set to true
+		this.GetComponent<BoxCollider> ().isTrigger = true;
+	}//end f'n void Awake()
 }

--- a/BasicMechanicsDemo/Assets/Scripts/Spell.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Spell.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(BoxCollider))]
 public class Spell : MonoBehaviour {
 	/**An enum variable for the spell name. See SpellName.cs for all spell names.*/
 	public SpellName m_SpellName { set; get;}
@@ -11,4 +12,10 @@ public class Spell : MonoBehaviour {
 	*It'd be simpler to just keep all the spells in the inventory from the get-go, but only show them to the player if they've been discovered.
 	*We can do the same basic thing with the items; if the player has 0 quantity of a given item, we won't show it.*/
 	public bool m_HasBeenDiscovered{ set; get;}
+
+	void Awake()
+	{
+		//ensure the box collider's isTrigger is set to true
+		this.GetComponent<BoxCollider> ().isTrigger = true;
+	}//end f'n void Awake()
 }

--- a/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn.meta
+++ b/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 13252c76d0f1440d685f9c3c993686ab
+folderAsset: yes
+timeCreated: 1508566153
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn/Spawner.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn/Spawner.cs
@@ -1,0 +1,81 @@
+﻿/*
+* A temp class for spawning items and whatever else could potentially be spawned, for testing purposes.
+*/
+
+#define TESTING_ITEM_PICKUP
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Spawner : MonoBehaviour {
+	#if TESTING_ITEM_PICKUP
+	/**A reference to the default item prefab to be spawned, before it is set to represent a specific item.*/
+	[SerializeField] private GameObject m_TempItemPrefab;
+	/**A reference to the default spell prefab to be spawned, before it is set to represent a specific spell.*/
+	[SerializeField] private GameObject m_TempSpellPrefab;
+	/**A reference to the player, just so we can consistently spawn something close to the player's transform.position.*/
+	[SerializeField] private GameObject m_Player;
+	#endif
+
+	/**A list of all Item instances we spawn.*/
+	private List<Item> m_ItemInstances;
+	/**A list of all Spell instances we spawn.*/
+	private List<Spell> m_SpellInstances;
+
+	void Start()
+	{
+		this.m_ItemInstances = new List<Item> ();
+		this.m_SpellInstances = new List<Spell>();
+	}
+
+	// Update is called once per frame
+	void Update () {
+		#if TESTING_ITEM_PICKUP
+		if (Input.GetKeyDown (KeyCode.Alpha1)) {
+			this.Spawn_Item_HealthPotion (this.m_Player.transform.position + Vector3.left * 2.0f);
+		}
+		if (Input.GetKeyDown (KeyCode.Alpha2)) {
+			this.Spawn_Spell_Fireball (this.m_Player.transform.position + Vector3.right * 2.0f);
+		}
+		#endif
+	}
+
+	/**Spawns a health potion at the given position.*/
+	public void Spawn_Item_HealthPotion(Vector3 position)
+	{
+		GameObject health_potion = GameObject.Instantiate (this.m_TempItemPrefab);
+		health_potion.transform.position = position;
+		Item health_potion_item = health_potion.GetComponent<Item> ();
+		health_potion_item = this.GenerateInstance_Item_HealthPotion ();
+		this.m_ItemInstances.Add (health_potion_item);
+	}//end f'n void Spawn_Item_HealthPotion(Vector3)
+
+	public void Spawn_Spell_Fireball(Vector3 position)
+	{
+		GameObject fireball = GameObject.Instantiate (this.m_TempSpellPrefab);
+		fireball.transform.position = position;
+		Spell fireball_spell = fireball.GetComponent<Spell> ();
+		fireball_spell = this.GenerateInstance_Spell_Fireball ();
+		this.m_SpellInstances.Add (fireball_spell);
+	}//end f'n void Spawn_Spell_Fireball(Vector3)
+
+	/**A private function to spawn a default health potion item; returns the instance of the Item.*/
+	private Item GenerateInstance_Item_HealthPotion()
+	{
+		Item health_potion = new Item ();
+		health_potion.m_ItemEffect = ItemEffect.Gain_Health;
+		health_potion.m_ItemName = ItemName.Health_Potion;
+		return health_potion;
+	}//end f'n Item GenerateInstance_Item_HealthPotion()
+
+	/**A private function to spawn a default fireball spell; returns the instance of the Spell.*/
+	private Spell GenerateInstance_Spell_Fireball()
+	{
+		Spell fireball = new Spell ();
+		fireball.m_SpellName = SpellName.Fireball;
+		fireball.m_SpellEffect = SpellEffect.Fire_Damage;
+		fireball.m_HasBeenDiscovered = false;
+		return fireball;
+	}//end f'n Spell GenerateInstance_Spell_Fireball()
+}

--- a/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn/Spawner.cs.meta
+++ b/BasicMechanicsDemo/Assets/Scripts/Temp_Spawn/Spawner.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9b69754a7e4cc4d5480b732a6704360b
+timeCreated: 1508566170
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/ProjectSettings/TagManager.asset
+++ b/BasicMechanicsDemo/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Item
+  - Spell
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Implemented basic functionalities for spawning of items and spells, as well as the ability to pick them up. The PlayerInventory::OnTriggerEnter function is being wonky, though. It somehow has time to execute twice while the player is just coming into the trigger. This is annoying because it's making it impossible to get a good idea of how many health_potions are in the player's inventory. We keep incrementing by 2 instead of 1, it sucks. Dunno how to fix this.
This was my output on my last attempt:
Spells:
Items:
Item name: Health_Potion	Item Effect: Gain_Health	Item Quantity:	2
Item name: Health_Potion	Item Effect: Gain_Health	Item Quantity:	2
Item name: Health_Potion	Item Effect: Gain_Health	Item Quantity:	2
See PlayerInventory.cs and Spawner.cs for output controls; look in the Update().
Spells can be picked up, and the inventory will adjust accordingly, at least.