### PR TITLE
Serialization; fixed problem with Vec3 not serializable

### DIFF
--- a/BasicMechanicsDemo/Assets/Scripts/Serialization/Serializable_Player.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Serialization/Serializable_Player.cs
@@ -10,8 +10,13 @@ public class Serializable_Player {
 	public List<int> m_ItemQuantities = new List<int>();
 	/**A list containing all spell name strings in the player inventory*/
 	public List<string> m_SpellNames = new List<string>();
-	/**A vector to store the player's position in the world at the time of the save.*/
-	public Vector3 m_PlayerPositionInWorld = new Vector3();
+//	/**A vector to store the player's position in the world at the time of the save.*/
+//	public Vector3 m_PlayerPositionInWorld = new Vector3();
+
+	public float m_PlayerPositionInWorld_X;
+	public float m_PlayerPositionInWorld_Y;
+	public float m_PlayerPositionInWorld_Z;
+
 	/**A variable to store the value of the player health*/
 	public float m_PlayerHealth;
 	/**A variable to store the maximal value of the player health*/
@@ -46,7 +51,10 @@ public class Serializable_Player {
 	/**A function to gather the player position in the world (little to do here, since the Vector3 format is serializable as it is).*/
 	public void GatherPlayerPosition(GameObject player)
 	{
-		this.m_PlayerPositionInWorld = player.transform.position;
+//		this.m_PlayerPositionInWorld = player.transform.position;
+		this.m_PlayerPositionInWorld_X = player.transform.position.x;
+		this.m_PlayerPositionInWorld_Y = player.transform.position.y;
+		this.m_PlayerPositionInWorld_Z = player.transform.position.z;
 	}//end f'n void GatherPlayerPosition(GameObject)
 
 	/**A function to gather all player attributes (health and mana, as well as the full possible value of each).*/

--- a/BasicMechanicsDemo/Assets/Scripts/Serialization/Serialization_Manager.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Serialization/Serialization_Manager.cs
@@ -14,7 +14,7 @@ public class Serialization_Manager : MonoBehaviour {
 		Serializable_Player SP = new Serializable_Player ();
 		m_SavedSessions.Add(SP.GenerateSerializableInstance(m_Player));
 		BinaryFormatter bf = new BinaryFormatter();
-		//Application.persistentDataPath is a string, so if you wanted you can put that into debug.log if you want to know where save games are located
+		Debug.Log (Application.persistentDataPath);
 		FileStream file = File.Create (Application.persistentDataPath + "/savedGames.gd"); //you can call it anything you want
 		bf.Serialize(file, m_SavedSessions);
 		file.Close();


### PR DESCRIPTION
I had to split the player's position into three separate floats; for whatever reason, a Vec3 can't be serialized. At least, not without us downloading something online, which we're obviously not allowed to do.
Everything runs smoothly now.