### PR TITLE
Clearer Spell Movement Assignment

### DIFF
--- a/BasicMechanicsDemo/Assets/AnimatorControllers/Player_MovementAndSpellcasting_AnimatorController.controller
+++ b/BasicMechanicsDemo/Assets/AnimatorControllers/Player_MovementAndSpellcasting_AnimatorController.controller
@@ -13,61 +13,61 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isMovingLeft
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isMovingUp
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isMovingDown
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isCastingSpell
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAlive
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFacingRight
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFacingLeft
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFacingUp
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFacingDown
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -523,6 +523,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: isFacingDown
     m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isCastingSpell
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102005949553518990}
   m_Solo: 0
@@ -745,6 +748,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: isFacingLeft
     m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isCastingSpell
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102983245290687178}
   m_Solo: 0
@@ -768,6 +774,9 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: isFacingRight
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isCastingSpell
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102317995974803804}
@@ -942,6 +951,9 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: isFacingUp
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isCastingSpell
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1102385836066510032}

--- a/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
+++ b/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
@@ -11039,7 +11039,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &672067010
 RectTransform:
   m_ObjectHideFlags: 0

--- a/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
+++ b/BasicMechanicsDemo/Assets/Scenes/BasicMovement.unity
@@ -13656,7 +13656,6 @@ MonoBehaviour:
   m_InventoryUIPrefab: {fileID: 126802963}
   m_MapUIPrefab: {fileID: 591261408}
   m_OptionsUIPrefab: {fileID: 1736946983}
-  m_TutorialManager: {fileID: 0}
   m_MenuOpen_Cursor: {fileID: 2800000, guid: 657b66ffafaf24de09529fac987ede50, type: 3}
   m_MenuClosed_Cursor: {fileID: 2800000, guid: 1c8702bb4e9c34c1a8c5441e0fa3ced7, type: 3}
 --- !u!224 &872955988

--- a/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
@@ -102,6 +102,43 @@ public class PlayerCastSpell : MonoBehaviour {
 			return;
 		}
 
+		//If the player at all touches the spell-casting input button...
+		if (Input.GetButton (STRINGKEY_INPUT_CASTSPELL)) {
+			//...and so long as the player wasn't clicking a UI button...
+			if (!this.PlayerIsClickingUIButton ()) {
+				//...if no spell is currently active...
+				if (this.m_SpellClassToFire == null) {
+					//...then update the currently chosen spell
+					this.UpdateChosenSpell ();
+				}//end if no spell is active
+
+				//It may be that this UpdateChosenSpell() sets the chosen spell, so the next if should NOT be an else
+
+				//...and if the player has a currently active spell at this point...
+				if (this.m_SpellClassToFire != null) {
+					//...and if the player is capable of casting a spell mana-wise...
+					if (this.m_Player.m_CanCastSpells) {
+						//...then cast the current spell
+						this.CastSpell ();
+					}//end if player has mana
+
+				}//end if active spell exists
+			
+			}//end if player isn't clicking UI button
+			//else if the player is clicking on a UI button...
+			else {
+				//...then update the corresponding bool and break us out of here
+				this.m_MenuOpen = true;
+				return;
+			}
+		}//end if player touched mouse input
+
+
+
+
+
+
+
 		if (Input.GetButtonDown (STRINGKEY_INPUT_CASTSPELL)){
 			//if the player's clicking on a UI button...
 			if (this.PlayerIsClickingUIButton ()) {
@@ -112,7 +149,7 @@ public class PlayerCastSpell : MonoBehaviour {
 
 			//else if the player's not toggling a menu and is capable of casting spells...
 			if (this.m_Player.m_CanCastSpells) {
-				this.CheckChosenSpell ();
+				this.UpdateChosenSpell ();
 				//if the spell to fire exists...
 				if (this.m_SpellClassToFire != null) {
 
@@ -198,7 +235,7 @@ public class PlayerCastSpell : MonoBehaviour {
 			}
 
 			if (this.m_Player.m_CanCastSpells) {
-				this.CheckChosenSpell ();
+				this.UpdateChosenSpell ();
 
 				//if the spell to fire exists 
 				if (this.m_SpellClassToFire != null) {
@@ -370,6 +407,12 @@ public class PlayerCastSpell : MonoBehaviour {
 		return value_to_return;
 	}//end f'n float GetAOESpellDuration(SpellName)
 
+	/**A function to be called */
+	private void CastSpell()
+	{
+		//
+	}
+
 	/**A function to apply AOE spells effects to all nearby enemies in a given radius.*/
 	private void ApplyAOEToEnemies(Vector3 position)
 	{
@@ -428,42 +471,15 @@ public class PlayerCastSpell : MonoBehaviour {
 										this.m_SpellClassToFire.m_SpellName == SpellName.Shield) ? true : false;
 	}//end f'n void ApplyPlayerAttributesAsResultOfMagic()
 
-//	/**A function to return the medium-most time for a clip in the animator.
-//	*This is to help us know when to destroy the gameobject such that the fade-out animation can play.*/
-//	private float TimeOfEndClip()
-//	{
-//		float shortest_clip_time = 1000.0f, medium_clip_time = 0.0f, longest_clip_time = 0.0f;
-//		foreach(AnimationClip clip in this.m_Animator.runtimeAnimatorController.animationClips)
-//		{
-//			//...if a given clip's length is greater than that of the longest clip's length...
-//			if (clip.length > longest_clip_time) {
-//				//...then update the longest clip
-//				longest_clip_time = clip.length;
-//			}//end if
-//			//...if a given clip's length is less than that of the shortest clip's length...
-//			if (clip.length < shortest_clip_time) {
-//				//...then update the shortest clip
-//				shortest_clip_time = clip.length;
-//			}//end if
-//			//...if a given clip's length is greater-than or equal to the shortest clip length
-//			//		AND that same given clip's length is less-than or equal to the longest clip length...
-//			if (clip.length >= shortest_clip_time && clip.length <= longest_clip_time) {
-//				//...then update the medium clip
-//				medium_clip_time = clip.length;
-//			}//end if
-//		}//end foreach
-//		Debug.Log(medium_clip_time);
-//		return medium_clip_time + 0.1f;
-//	}//end f'n float TimeOfEndClip()
 
 	/**Used to retrieve the current spell from the inventory.*/
-	private void CheckChosenSpell()
+	private void UpdateChosenSpell()
 	{
 		this.m_SpellClassToFire = this.gameObject.GetComponent<PlayerInventory>().m_ActiveSpellClass;
 		this.m_SpellName = this.m_SpellClassToFire.m_SpellName.ToString ();
 			
 
-	}//end f'n void CheckChosenSpell()
+	}//end f'n void UpdateChosenSpell()
 
 	/**A function to update the player animator with regards to the player spell casting animations.*/
 	private void UpdateAnimatorParameters()

--- a/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
@@ -40,7 +40,7 @@ public class PlayerCastSpell : MonoBehaviour {
 	/**A string variable containing the string name of the isCastingSpell parameter in the player animator.*/
 	private readonly string STRINGKEY_PARAM_CASTSPELL = "isCastingSpell";
 	/**A bool variable to let us know whether or not the player's in the process of casting a spell.*/
-	private bool m_isCastingSpell;
+	public bool m_isCastingSpell;
 
 	/**The player animator, including the bit about casting spells.*/
 	private Animator m_Animator;
@@ -71,6 +71,8 @@ public class PlayerCastSpell : MonoBehaviour {
 	/**A bool to tell us whether or not a given menu is open; if so, the player shouldn't be able to cast spells.*/
 	public bool m_MenuOpen = true;
 
+	private float m_InputTimer = 0.0f;
+
 	void Start()
 	{
 		this.m_Animator = this.GetComponent<Animator> ();
@@ -78,6 +80,227 @@ public class PlayerCastSpell : MonoBehaviour {
 		this.m_SpellClassToFire = this.GetComponent<PlayerInventory> ().m_ActiveSpellClass;
 		this.m_playerAudio = this.GetComponent<PlayerAudio> ();
     }
+
+	/**A function to be called if the long list of conditions for spell-casting to be valid are met; assigns the respective movement for the corresponding spell type. 
+	 * When this function is called the player could be either pressing or holding the mouse.*/
+	private void AssignSpellMovement()
+	{
+		//If the input button is tapped
+		if (Input.GetButtonDown (STRINGKEY_INPUT_CASTSPELL)) {
+			if (!this.m_SpellClassToFire.m_IsPersistent) {
+				Debug.Log ("The mouse was pressed");
+				switch ((int)this.m_SpellClassToFire.m_SpellType) {
+				case (int)SpellType.BASIC_PROJECTILE_ON_TARGET:
+					{
+						//All basic projectile spells have the same movement pattern
+
+						Ray ray = this.m_MainCamera.ScreenPointToRay (Input.mousePosition);
+						RaycastHit[] targets_hit = Physics.RaycastAll (ray);
+						//We need to find the raycast hit furthest from the camera in the event that none of the raycasthits are 
+						//mobile character as the furthest raycast hit will be the ground.
+						RaycastHit furthest = targets_hit [0];
+						bool any_mobile_characters = false;
+						foreach (RaycastHit hit in targets_hit) {
+
+							//if the hit's distance is greater than that of the furthest...
+							if (hit.distance > furthest.distance) {
+								//...then update the furthest
+								furthest = hit;
+							}//end if
+
+							//if the hit has a MobileCharacter component...
+							if (hit.collider.gameObject.GetComponent<MobileCharacter> () != null) {
+								m_Target = hit.collider.gameObject;
+								this.m_SpellCubeInstance = GameObject.Instantiate (this.m_SpellCube);
+								this.m_Player.m_audioSource.PlayOneShot(m_playerAudio.getAudioForSpell(this.m_SpellClassToFire.m_SpellName));
+								this.m_SpellCubeInstance.transform.position = this.transform.position;
+								SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+								spell_movement.m_IsMobileCharacter = true;
+								spell_movement.SetTarget (hit);
+								any_mobile_characters = true;
+								spell_movement.SetSpellToCast (this.m_SpellClassToFire);
+
+								this.m_SpellAnimatorManager.SetSpellAnimator (this.m_SpellCubeInstance);
+								//return to ensure we only launch one spell
+								return;
+							}//end if
+						}//end foreach
+
+						//if none of the gameobjects found in the raycastall were mobile characters...
+						if (!any_mobile_characters) {
+							//...then send the spell to the furthest Raycast hit
+							#if TESTING_SPELLMOVEMENT
+							Debug.Log("PlayerCastSpell::Update\tNo mobile characters found\tRay hit\tx: " + furthest.point.x
+							+ " y: " + furthest.point.y + " z: " + furthest.point.z);
+							#endif
+							this.m_SpellCubeInstance = GameObject.Instantiate (this.m_SpellCube);
+							this.m_Player.m_audioSource.PlayOneShot(m_playerAudio.getAudioForSpell(this.m_SpellClassToFire.m_SpellName));
+							this.m_SpellCubeInstance.transform.position = this.transform.position;
+							SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+							spell_movement.m_IsMobileCharacter = false;
+							spell_movement.SetTarget (furthest);
+
+							spell_movement.SetSpellToCast (this.m_SpellClassToFire);
+
+							this.m_SpellAnimatorManager.SetSpellAnimator (this.m_SpellCubeInstance);
+
+							GameObject.Destroy (this.m_SpellCubeInstance, TIME_UNTIL_DESTROY);
+						}//end if
+
+						//However, most (if not all) basic projectile spells have different effects on both enemies and player mana.
+						switch ((int)this.m_SpellClassToFire.m_SpellName) {
+						case (int)SpellName.Fireball:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.FIREBALL_MANA_COST);
+								break;
+							}//end case Fireball
+						case (int)SpellName.Iceball:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.ICEBALL_MANA_COST);
+								break;
+							}//end case Iceball
+						case (int)SpellName.Thunderball:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.THUNDERBALL_MANA_COST);
+								break;
+							}//end case Thunderball
+						}//end switch
+
+						break;
+					}//end case basic projectile on target
+				}//end switch
+			}//end if active spell is not persistent
+		}//end if mouse is pressed
+		//else if mouse is held
+		else if ((Input.GetButton (STRINGKEY_INPUT_CASTSPELL)))
+		{
+			//if the active spell is persistent
+			if (this.m_SpellClassToFire.m_IsPersistent) {
+//				Debug.Log ("The mouse was held");
+				switch ((int)this.m_SpellClassToFire.m_SpellType) {
+				case (int)SpellType.ON_PLAYER:
+					{
+						//Any spell cast on the player has the same basic movement pattern
+
+						//if the spell cube instance is null (which can only mean the last spell cube was destroyed)...
+						if (this.m_SpellCubeInstance == null) {
+							//...then create a new spell cube
+							this.m_SpellCubeInstance = GameObject.Instantiate (this.m_SpellCube);
+							this.m_Player.m_audioSource.PlayOneShot (m_playerAudio.getAudioForSpell (this.m_SpellClassToFire.m_SpellName));
+							this.m_SpellCubeInstance.transform.position = this.transform.position;
+							SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+							spell_movement.SetSpellToCast (this.m_SpellClassToFire);
+							this.m_SpellAnimatorManager.SetSpellAnimator (this.m_SpellCubeInstance);
+						}//end if
+						//if the spell cube instance exists (meaning we're in the process of casting a spell)...
+						if (this.m_SpellCubeInstance != null) {
+							//...then ensure the spell's always at our chosen position
+							SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+							spell_movement.MaintainPosition (this.transform.position);
+						}//end if the spell cube instance exists
+
+						//However, most (if not all) on-player spells have different effects on both enemies and player mana.
+						switch ((int)this.m_SpellClassToFire.m_SpellName) {
+						case (int)SpellName.Shield:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.SHIELD_MANA_COST);
+								this.m_Player.m_IsShielded = true;
+								break;
+							}//end case Shield
+						case (int)SpellName.Heal:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.HEAL_MANA_COST);
+								//Some arbitrary value just to test
+								this.m_Player.AffectHealth (2.0f);
+								break;
+							}//end case Heal
+						}//end switch
+
+						break;
+					}//end case ON PLAYER
+				case (int)SpellType.AOE_ON_TARGET:
+					{
+						//Any AOE spell cast on a target has the same basic movement pattern
+
+						//if the spell cube instance is null (which can only mean the last spell cube was destroyed)...
+						if (this.m_SpellCubeInstance == null) {
+							//...then create a new spell cube
+							this.m_SpellCubeInstance = GameObject.Instantiate (this.m_SpellCube);
+							this.m_Player.m_audioSource.PlayOneShot (m_playerAudio.getAudioForSpell (this.m_SpellClassToFire.m_SpellName));
+							this.m_SpellCubeInstance.transform.position = this.transform.position;
+							SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+							spell_movement.SetSpellToCast (this.m_SpellClassToFire);
+							this.m_SpellAnimatorManager.SetSpellAnimator (this.m_SpellCubeInstance);
+						}//end if
+						//if the spell cube instance exists (meaning we're in the process of casting a spell)...
+						if (this.m_SpellCubeInstance != null) {
+							//...then ensure the spell's always at our chosen position
+							SpellMovement spell_movement = this.m_SpellCubeInstance.GetComponent<SpellMovement> ();
+							Ray ray = this.m_MainCamera.ScreenPointToRay (Input.mousePosition);
+							RaycastHit[] targets_hit = Physics.RaycastAll (ray);
+
+							RaycastHit target = targets_hit [0];
+							bool any_mobile_characters = false;
+							foreach (RaycastHit hit in targets_hit) {
+								//if the hit's distance is greater than that of the furthest...
+								if (hit.collider.gameObject == this.m_Floor) {
+									target = hit;
+									break;
+								}
+							}//end foreach
+							//Set position of AOE spell animation
+							Vector3 modified_target = new Vector3 (target.point.x, 0.0f, target.point.z);
+							Vector3 position = modified_target + AOE_offset;
+							spell_movement.MaintainPosition (position);
+
+							//If we're just starting to cast the spell...
+							if (this.AOE_Timer == 0.0f) {
+								//... then apply the AOE to the enemies
+								this.ApplyAOEToEnemies (position - AOE_offset);
+								//Then set AOE timer to 1, to avoid repeating the base case
+								this.AOE_Timer = 1.0f;
+							}//end if
+							//else if the AOE timer is greater than or equal to 1 + the time it takes for the specific AOE spell to wear off...
+							else if (this.AOE_Timer >= 1.0f + this.m_SpellClassToFire.m_EffectDuration) {
+								//...then apply damage to the enemies and reset AOE timer to 1.0f
+								this.ApplyAOEToEnemies (position - AOE_offset);
+								this.AOE_Timer = 1.0f;
+							}//end else if
+							//else increment AOE timer by time.delta time
+							else {
+								this.AOE_Timer += Time.deltaTime;
+							}//end else
+						}//end if the spell cube instance exists
+
+						//However, most (if not all) AOE on-target spells have different effects on both enemies and player mana.
+						switch ((int)this.m_SpellClassToFire.m_SpellName) {
+						case (int)SpellName.Thunderstorm:
+							{
+								this.m_Player.AffectMana (-this.m_SpellClassToFire.THUNDERSTORM_MANA_COST);
+								break;
+							}//end case thunderstorm
+						}//end switch
+
+						break;
+					}//end case AOE ON TARGET
+				}//end switch
+			}//end if active spell is persistent
+		}//end if mouse is held
+	}
+
+	/**A function to return the player to normal if they're casting an active spell and run out of mana or let go of the spellcasting button*/
+	private void NormalizePlayerStatus()
+	{
+		if (this.m_SpellClassToFire.m_SpellType == SpellType.ON_PLAYER) {
+			switch ((int)this.m_SpellClassToFire.m_SpellName) {
+			case (int)SpellName.Shield:
+				{
+					this.m_Player.m_IsShielded = false;
+					break;
+				}
+			}
+		}
+	}
 
 	// Update is called once per frame
 	void Update () {
@@ -102,24 +325,41 @@ public class PlayerCastSpell : MonoBehaviour {
 			return;
 		}
 
+//		Debug.Log (this.m_SpellClassToFire != null
+//			&& this.m_SpellCubeInstance != null
+//			&& this.m_SpellClassToFire.m_IsPersistent
+//			&& (Input.GetButtonUp (STRINGKEY_INPUT_CASTSPELL) || !this.m_Player.m_CanCastSpells));
+//		
+		//if the active spell exists
+		//AND the spell cube instance (representative of the spell instance in the scene) exists
+		//AND the active spell in question is persistent
+		//AND either the user lets go of the mouse OR the player runs out of mana
+		if (this.m_SpellClassToFire != null
+			&& this.m_SpellCubeInstance != null
+			&& this.m_SpellClassToFire.m_IsPersistent
+			&& (Input.GetButtonUp (STRINGKEY_INPUT_CASTSPELL) || !this.m_Player.m_CanCastSpells))
+		{
+			//...then destroy the spell instance in the scene
+			GameObject.Destroy(this.m_SpellCubeInstance);
+			this.m_isCastingSpell = false;
+			this.NormalizePlayerStatus ();
+		}//end if
+
+		//Input management
+
 		//If the player at all touches the spell-casting input button...
 		if (Input.GetButton (STRINGKEY_INPUT_CASTSPELL)) {
+			//Increment input timer to differentiate between a tap and a hold
+//			this.m_InputTimer += Time.deltaTime;
 			//...and so long as the player wasn't clicking a UI button...
 			if (!this.PlayerIsClickingUIButton ()) {
-				//...if no spell is currently active...
-				if (this.m_SpellClassToFire == null) {
-					//...then update the currently chosen spell
-					this.UpdateChosenSpell ();
-				}//end if no spell is active
-
-				//It may be that this UpdateChosenSpell() sets the chosen spell, so the next if should NOT be an else
-
 				//...and if the player has a currently active spell at this point...
 				if (this.m_SpellClassToFire != null) {
 					//...and if the player is capable of casting a spell mana-wise...
 					if (this.m_Player.m_CanCastSpells) {
-						//...then cast the current spell
-						this.CastSpell ();
+						this.m_isCastingSpell = true;
+						//...then set up the spell movement for the corresponding spell
+						this.AssignSpellMovement ();
 					}//end if player has mana
 
 				}//end if active spell exists
@@ -132,8 +372,15 @@ public class PlayerCastSpell : MonoBehaviour {
 				return;
 			}
 		}//end if player touched mouse input
+		//else if player didn't touch mouse input
+		else {
+			this.m_isCastingSpell = false;
+		}
 
 
+		this.UpdateAnimatorParameters ();
+
+		return;
 
 
 
@@ -406,13 +653,7 @@ public class PlayerCastSpell : MonoBehaviour {
 		}//end switch
 		return value_to_return;
 	}//end f'n float GetAOESpellDuration(SpellName)
-
-	/**A function to be called */
-	private void CastSpell()
-	{
-		//
-	}
-
+		
 	/**A function to apply AOE spells effects to all nearby enemies in a given radius.*/
 	private void ApplyAOEToEnemies(Vector3 position)
 	{

--- a/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Character/Mobile/Player/PlayerCastSpell.cs
@@ -103,15 +103,11 @@ public class PlayerCastSpell : MonoBehaviour {
 		}
 
 		if (Input.GetButtonDown (STRINGKEY_INPUT_CASTSPELL)){
-			//First check to see if we're trying to toggle a menu
-			RaycastHit menu_check_hit;
-			Ray menu_check_ray = this.m_MainCamera.ScreenPointToRay (Input.mousePosition);
-			if (Physics.Raycast(menu_check_ray, out menu_check_hit))
-			{
-				if (menu_check_hit.collider.gameObject.GetComponent<UnityEngine.UI.Button> () != null) {
-					this.m_MenuOpen = true;
-					return;
-				}
+			//if the player's clicking on a UI button...
+			if (this.PlayerIsClickingUIButton ()) {
+				//...then update the corresponding bool, and break us out of here.
+				this.m_MenuOpen = true;
+				return;
 			}
 
 			//else if the player's not toggling a menu and is capable of casting spells...
@@ -192,17 +188,13 @@ public class PlayerCastSpell : MonoBehaviour {
 			}//end if
 		}//end if
 		//else if the user holds down the mouse...
-//		else if (Input.GetButton (STRINGKEY_INPUT_CASTSPELL) && this.m_Player.m_CanCastSpells) {
 		else if (Input.GetButton(STRINGKEY_INPUT_CASTSPELL)){
-			//First check to see if we're trying to toggle a menu
-			RaycastHit menu_check_hit;
-			Ray menu_check_ray = this.m_MainCamera.ScreenPointToRay (Input.mousePosition);
-			if (Physics.Raycast(menu_check_ray, out menu_check_hit))
-			{
-				if (menu_check_hit.collider.gameObject.GetComponent<UnityEngine.UI.Button> () != null) {
-					this.m_MenuOpen = true;
-					return;
-				}
+
+			//if the player's clicking on a UI button...
+			if (this.PlayerIsClickingUIButton ()) {
+				//...then update the corresponding bool, and break us out of here.
+				this.m_MenuOpen = true;
+				return;
 			}
 
 			if (this.m_Player.m_CanCastSpells) {
@@ -342,6 +334,21 @@ public class PlayerCastSpell : MonoBehaviour {
 
 		this.UpdateAnimatorParameters ();
 	}//end f'n void Update()
+
+	/**A private helper function to tell us whether or not when the user clicks they are in fact clicking on a UI button*/
+	private bool PlayerIsClickingUIButton()
+	{
+		//First check to see if we're trying to toggle a menu
+		RaycastHit menu_check_hit;
+		Ray menu_check_ray = this.m_MainCamera.ScreenPointToRay (Input.mousePosition);
+		if (Physics.Raycast(menu_check_ray, out menu_check_hit))
+		{
+			if (menu_check_hit.collider.gameObject.GetComponent<UnityEngine.UI.Button> () != null) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	/**A function to return an AOE spell's duration*/
 	private float GetAOESpellDuration(SpellName spell_name)

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/SpellInputType.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/SpellInputType.cs
@@ -1,0 +1,4 @@
+﻿
+public enum SpellInputType {
+
+}

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/SpellInputType.cs.meta
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/SpellInputType.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 558ab8c999aba42adb4e91608e5fc5c3
+timeCreated: 1510558213
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/SpellType.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/SpellType.cs
@@ -1,0 +1,8 @@
+﻿/**An enum to contain all spell types.*/
+
+public enum SpellType{
+	ON_PLAYER = 0,
+	BASIC_PROJECTILE_ON_TARGET,
+	AOE_ON_PLAYER, 
+	AOE_ON_TARGET
+}

--- a/BasicMechanicsDemo/Assets/Scripts/Enums/SpellType.cs.meta
+++ b/BasicMechanicsDemo/Assets/Scripts/Enums/SpellType.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b6903753602cf4dde8453a160aa8223b
+timeCreated: 1510556781
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicMechanicsDemo/Assets/Scripts/NormalClasses/SpellClass.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/NormalClasses/SpellClass.cs
@@ -97,7 +97,9 @@ public class SpellClass {
 				spellinstance_to_return.m_SpellName = SpellName.Thunderstorm;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.AOE_Shock;
 				spellinstance_to_return.m_SpellType = SpellType.AOE_ON_TARGET;
-				spellinstance_to_return.m_EffectDuration = 0.0f;
+				//While it is true that thunderstorm can be used indefinitely, the effects of this spell are electrocution for a given 
+				//time; it therefore has a duration value 
+				spellinstance_to_return.m_EffectDuration = 1.25f;
 				spellinstance_to_return.m_IsMobileSpell = false;
 				spellinstance_to_return.m_IsAOESpell = true;
 				spellinstance_to_return.m_ManaCost = THUNDERSTORM_MANA_COST;

--- a/BasicMechanicsDemo/Assets/Scripts/NormalClasses/SpellClass.cs
+++ b/BasicMechanicsDemo/Assets/Scripts/NormalClasses/SpellClass.cs
@@ -6,6 +6,13 @@ public class SpellClass {
 	public SpellName m_SpellName;
 	/**An enum variable for the spell effect. See SpellEffect.cs for all spell effects.*/
 	public SpellEffect m_SpellEffect;
+	/**An enum variable for the spell type. See SpellType.cs for all spell types.*/
+	public SpellType m_SpellType;
+	/**A float to denote the duration of the spell's effect; note: the duration of a spell is defined as being the that which occurs after the spell hits the enemy.
+	*So in the case of a spell like Iceball, we ask ourselves "For how long is the enemy frozen after being hit?".
+	*Also note that in the context of spells that are held down, like Shield or Heal, this parameter is infinite and has no real relevance. We therefore set it to 0 in those cases.*/
+	public float m_EffectDuration = 0.0f;
+
 	/**A bool to tell us whether or not a spellclass instance is mobile.
 	*A mobile spell is a spell that is cast by the player at an enemy (i.e. Fireball), that moves around.
 	*An immobile spell is a spell that is cast by the player on the player (i.e. Heal, Shield), that stays fixed on the player.*/
@@ -45,6 +52,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Fireball;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.Fire_Damage;
+				spellinstance_to_return.m_SpellType = SpellType.BASIC_PROJECTILE_ON_TARGET;
+				spellinstance_to_return.m_EffectDuration = 0.0f;
 				spellinstance_to_return.m_IsMobileSpell = true;
 				spellinstance_to_return.m_ManaCost = FIREBALL_MANA_COST;
 				spellinstance_to_return.m_IsPersistent = false;
@@ -54,6 +63,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Shield;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.Damage_Resistance;
+				spellinstance_to_return.m_SpellType = SpellType.ON_PLAYER;
+				spellinstance_to_return.m_EffectDuration = 0.0f;
 				spellinstance_to_return.m_IsMobileSpell = false;
 				spellinstance_to_return.m_ManaCost = SHIELD_MANA_COST;
 				spellinstance_to_return.m_IsPersistent = true;
@@ -63,6 +74,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Iceball;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.Ice_Freeze;
+				spellinstance_to_return.m_SpellType = SpellType.BASIC_PROJECTILE_ON_TARGET;
+				spellinstance_to_return.m_EffectDuration = 2.5f;
 				spellinstance_to_return.m_IsMobileSpell = true;
 				spellinstance_to_return.m_ManaCost = ICEBALL_MANA_COST;
 				spellinstance_to_return.m_IsPersistent = false;
@@ -72,6 +85,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Thunderball;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.Shock_Damage;
+				spellinstance_to_return.m_SpellType = SpellType.BASIC_PROJECTILE_ON_TARGET;
+				spellinstance_to_return.m_EffectDuration = 1.25f;
 				spellinstance_to_return.m_IsMobileSpell = true;
 				spellinstance_to_return.m_ManaCost = THUNDERBALL_MANA_COST;
 				spellinstance_to_return.m_IsPersistent = false;
@@ -81,6 +96,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Thunderstorm;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.AOE_Shock;
+				spellinstance_to_return.m_SpellType = SpellType.AOE_ON_TARGET;
+				spellinstance_to_return.m_EffectDuration = 0.0f;
 				spellinstance_to_return.m_IsMobileSpell = false;
 				spellinstance_to_return.m_IsAOESpell = true;
 				spellinstance_to_return.m_ManaCost = THUNDERSTORM_MANA_COST;
@@ -91,6 +108,8 @@ public class SpellClass {
 			{
 				spellinstance_to_return.m_SpellName = SpellName.Heal;
 				spellinstance_to_return.m_SpellEffect = SpellEffect.Heal_Player;
+				spellinstance_to_return.m_SpellType = SpellType.ON_PLAYER;
+				spellinstance_to_return.m_EffectDuration = 0.0f;
 				spellinstance_to_return.m_IsMobileSpell = false;
 				spellinstance_to_return.m_IsAOESpell = false;
 				spellinstance_to_return.m_ManaCost = HEAL_MANA_COST;
@@ -113,7 +132,7 @@ public class SpellClass {
 	{
 		string message = "SpellClass::ReturnSpellInstanceInfo()\t:\tSpell Name: " + this.m_SpellName.ToString ()
 			+ "\tSpell Effect: " + this.m_SpellEffect.ToString () + "\tisMobile? " + this.m_IsMobileSpell + "\tisAOE? " 
-			+ this.m_IsAOESpell;
+			+ this.m_IsAOESpell + " Spell type: " + this.m_SpellType.ToString();
 		return message;
 	}//end f'n string ReturnSpellInstanceInfo()
 }//end class SpellClass


### PR DESCRIPTION
Created a function to assign spell movement with respect to user input, the spell type, its persistence, and finally the spell name itself. This will be much clearer than what we were using before. I've not removed anything as of yet; if you want to look at it, head on over to PlayerCastSpell.cs. You'll note that the Update() function has a return somewhere below the new things I've added, to prevent it from doing any extra unnecessary computations.